### PR TITLE
[codex] fix php freetype paths

### DIFF
--- a/plugins/php/versions/52/gd.sh
+++ b/plugins/php/versions/52/gd.sh
@@ -80,10 +80,19 @@ Install_lib()
 		cd $sourcePath/php${version}/ext/${LIBNAME}
 		
 		$serverPath/php/$version/bin/phpize
+		FREETYPE_DIR=${serverPath}/lib/freetype_old
+		if [ ! -d "$FREETYPE_DIR" ] && command -v pkg-config >/dev/null 2>&1; then
+			if pkg-config --exists freetype2; then
+				SYS_FREETYPE_DIR=`pkg-config --variable=prefix freetype2 2>/dev/null`
+				if [ -n "$SYS_FREETYPE_DIR" ]; then
+					FREETYPE_DIR="$SYS_FREETYPE_DIR"
+				fi
+			fi
+		fi
 		./configure --with-php-config=$serverPath/php/$version/bin/php-config \
 		--with-gd \
 		--with-jpeg-dir=/usr/lib \
-		--with-freetype-dir=${serverPath}/lib/freetype_old \
+		--with-freetype-dir=${FREETYPE_DIR} \
 		--enable-gd-native-ttf
 
 		make clean && make && make install && make clean

--- a/plugins/php/versions/52/install.sh
+++ b/plugins/php/versions/52/install.sh
@@ -84,7 +84,8 @@ fi
 
 OPTIONS='--without-iconv'
 if [ $sysName == 'Darwin' ]; then
-	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype"
+	cd ${rootPath}/plugins/php/lib && /bin/bash freetype_old.sh
+	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype_old"
 fi
 
 IS_64BIT=`getconf LONG_BIT`

--- a/plugins/php/versions/53/install.sh
+++ b/plugins/php/versions/53/install.sh
@@ -67,7 +67,8 @@ fi
 OPTIONS='--without-iconv'
 
 if [ $sysName == 'Darwin' ]; then
-	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype"
+	cd ${rootPath}/plugins/php/lib && /bin/bash freetype_old.sh
+	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype_old"
 fi
 
 IS_64BIT=`getconf LONG_BIT`

--- a/plugins/php/versions/54/install.sh
+++ b/plugins/php/versions/54/install.sh
@@ -59,7 +59,7 @@ fi
 
 OPTIONS='--without-iconv'
 if [ $sysName == 'Darwin' ]; then
-	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype"
+	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype_old"
 	# OPTIONS="${OPTIONS} --with-pcre-dir=${serverPath}/lib/pcre"
 	# OPTIONS="${OPTIONS} --with-external-pcre=${serverPath}/lib/pcre"
 else

--- a/plugins/php/versions/55/install.sh
+++ b/plugins/php/versions/55/install.sh
@@ -59,7 +59,7 @@ fi
 
 OPTIONS='--without-iconv'
 if [ $sysName == 'Darwin' ]; then
-	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype"
+	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype_old"
 else
 	OPTIONS="${OPTIONS} --with-readline"
 fi

--- a/plugins/php/versions/56/install.sh
+++ b/plugins/php/versions/56/install.sh
@@ -61,7 +61,7 @@ fi
 
 OPTIONS='--without-iconv'
 if [ $sysName == 'Darwin' ]; then
-	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype"
+	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype_old"
 	OPTIONS="${OPTIONS} --with-zlib-dir=$(brew --prefix zlib)"
 else
 	OPTIONS="${OPTIONS} --with-readline"

--- a/plugins/php/versions/70/install.sh
+++ b/plugins/php/versions/70/install.sh
@@ -59,7 +59,7 @@ fi
 
 OPTIONS='--without-iconv'
 if [ $sysName == 'Darwin' ]; then
-	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype"
+	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype_old"
 	# OPTIONS="${OPTIONS} --with-external-pcre=$(brew --prefix pcre2)"
 else
 	OPTIONS="${OPTIONS} --with-readline"

--- a/plugins/php/versions/71/install.sh
+++ b/plugins/php/versions/71/install.sh
@@ -61,7 +61,7 @@ fi
 OPTIONS=''
 OPTIONS='--without-iconv'
 if [ $sysName == 'Darwin' ]; then
-	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype"
+	OPTIONS="${OPTIONS} --with-freetype-dir=${serverPath}/lib/freetype_old"
 	OPTIONS="${OPTIONS} --with-external-pcre=$(brew --prefix pcre2)"
 else
 	OPTIONS="${OPTIONS} --with-readline"

--- a/plugins/php/versions/common/gd_old.sh
+++ b/plugins/php/versions/common/gd_old.sh
@@ -79,10 +79,18 @@ Install_lib()
 			OPTIONS="$OPTIONS --with-xpm-dir"
 		fi
 
-		find_ft2=`pkg-config --list-all | grep freetype2`
-		if [ "$find_ft2" == "" ];then
-			OPTIONS="$OPTIONS --with-freetype-dir=${serverPath}/lib/freetype_old"
+		# Old PHP GD must receive an explicit freetype path, otherwise it
+		# is built without freetype support and CAPTCHA images stop working.
+		FREETYPE_DIR=${serverPath}/lib/freetype_old
+		if [ ! -d "$FREETYPE_DIR" ] && command -v pkg-config >/dev/null 2>&1; then
+			if pkg-config --exists freetype2; then
+				SYS_FREETYPE_DIR=`pkg-config --variable=prefix freetype2 2>/dev/null`
+				if [ -n "$SYS_FREETYPE_DIR" ]; then
+					FREETYPE_DIR="$SYS_FREETYPE_DIR"
+				fi
+			fi
 		fi
+		OPTIONS="$OPTIONS --with-freetype-dir=${FREETYPE_DIR}"
 		
 
 		#--with-xpm


### PR DESCRIPTION
## What changed
- Unified old PHP GD builds to always resolve a usable freetype directory instead of skipping it when `pkg-config` can see `freetype2`.
- Fixed the old PHP 5.2-5.7 install scripts so their Darwin freetype path matches the `freetype_old` build they rely on.
- Updated the PHP 5.2 GD extension installer to use the same fallback logic as the shared old-GD path.

## Why
- On clean Debian 12 installs, PHP 5.6 could build GD without freetype support, which breaks captcha image rendering.
- Some older install scripts also pointed at `lib/freetype` while building or installing `freetype_old`, which made the old toolchain inconsistent.

## Validation
- Ran `bash -n` on every modified shell script.
