### PR TITLE
Use PowerLinux releases for update checks

### DIFF
--- a/scripts/init.d/mw.tpl
+++ b/scripts/init.d/mw.tpl
@@ -375,8 +375,8 @@ mw_install(){
     fi
 
     mw_common_proxy
-    echo "bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/midoks/mdserver-web/master/scripts/install.sh")"
-    bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/midoks/mdserver-web/master/scripts/install.sh")
+    echo "bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/AndyXeCM/PowerLinux/main/scripts/install.sh")"
+    bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/AndyXeCM/PowerLinux/main/scripts/install.sh")
 }
 
 mw_update()
@@ -387,8 +387,8 @@ mw_update()
     fi
 
     mw_common_proxy
-    echo "bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/midoks/mdserver-web/master/scripts/update.sh")"
-    bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/midoks/mdserver-web/master/scripts/update.sh")
+    echo "bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/AndyXeCM/PowerLinux/main/scripts/update.sh")"
+    bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/AndyXeCM/PowerLinux/main/scripts/update.sh")
 }
 
 mw_update_dev()
@@ -399,8 +399,8 @@ mw_update_dev()
     fi
 
     mw_common_proxy
-    echo "bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/midoks/mdserver-web/dev/scripts/update_dev.sh")"
-    bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/midoks/mdserver-web/dev/scripts/update_dev.sh")
+    echo "bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/AndyXeCM/PowerLinux/main/scripts/update_dev.sh")"
+    bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/AndyXeCM/PowerLinux/main/scripts/update_dev.sh")
     
     cd ${PANEL_DIR}
 }
@@ -412,8 +412,8 @@ mw_update_venv()
     rm -rf ${PANEL_DIR}/lib
 
     mw_common_proxy
-    echo "bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/midoks/mdserver-web/dev/scripts/update_dev.sh")"
-    bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/midoks/mdserver-web/dev/scripts/update_dev.sh")
+    echo "bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/AndyXeCM/PowerLinux/main/scripts/update_dev.sh")"
+    bash <(curl -fsSL "${HTTP_PREFIX}raw.githubusercontent.com/AndyXeCM/PowerLinux/main/scripts/update_dev.sh")
     
     cd ${PANEL_DIR}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,7 +15,7 @@ ERROR='[\033[31mERROR\033[0m]'
 WORKING='[\033[34m*\033[0m]'
 REPO_OWNER="AndyXeCM"
 REPO_NAME="PowerLinux"
-REPO_BRANCH="master"
+REPO_BRANCH="main"
 
 
 # LANG=en_US.UTF-8
@@ -152,7 +152,7 @@ if [ "$LOCAL_ADDR" != "common" ];then
 fi
 
 if [ -f /etc/motd ];then
-    echo "welcome to mdserver-web panel" > /etc/motd
+    echo "welcome to PowerLinux panel" > /etc/motd
 fi
 
 startTime=`date +%s`

--- a/scripts/install/macos.sh
+++ b/scripts/install/macos.sh
@@ -5,6 +5,9 @@ LANG=en_US.UTF-8
 
 USER=$(who | sed -n "2,1p" |awk '{print $1}')
 DEV="/Users/${USER}/Desktop/mwdev"
+REPO_OWNER="AndyXeCM"
+REPO_NAME="PowerLinux"
+REPO_BRANCH="main"
 
 
 mkdir -p $DEV
@@ -31,11 +34,12 @@ brew install pcre2 libxpm libelf
 brew install automake icu4c libmemcached
 
 if [ ! -d $DEV/server/mdserver-web ]; then
-	wget -O /tmp/master.zip https://codeload.github.com/midoks/mdserver-web/zip/master
+	wget -O /tmp/master.zip https://codeload.github.com/${REPO_OWNER}/${REPO_NAME}/zip/${REPO_BRANCH}
+	TARBALL_DIR=$(unzip -Z1 /tmp/master.zip | head -1 | cut -d/ -f1)
 	cd /tmp && unzip /tmp/master.zip
-	mv /tmp/mdserver-web-master $DEV/server/mdserver-web
+	mv /tmp/${TARBALL_DIR} $DEV/server/mdserver-web
 	rm -f /tmp/master.zip
-	rm -rf /tmp/mdserver-web-master
+	rm -rf /tmp/${TARBALL_DIR}
 fi
 
 if [ ! -d $DEV/server/lib ]; then

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -16,6 +16,9 @@ WORKING='[\033[34m*\033[0m]'
 
 # LANG=en_US.UTF-8
 is64bit=`getconf LONG_BIT`
+REPO_OWNER="AndyXeCM"
+REPO_NAME="PowerLinux"
+REPO_BRANCH="main"
 
 
 if [ -f /www/server/mdserver-web/tools.py ];then
@@ -25,8 +28,8 @@ if [ -f /www/server/mdserver-web/tools.py ];then
 	exit 0
 fi
 
-echo -e "您正在安装的是\033[31mmdserver-web测试版\033[0m，非开发测试用途请使用正式版 install.sh ！" 
-echo -e "You are installing\033[31m mdserver-web dev version\033[0m, normally use install.sh for production.\n" 
+echo -e "您正在安装的是\033[31mPowerLinux测试版\033[0m，非开发测试用途请使用正式版 install.sh ！"
+echo -e "You are installing\033[31m PowerLinux dev version\033[0m, normally use install.sh for production.\n"
 sleep 1
 
 LOG_FILE=/var/log/mw-install.log
@@ -153,7 +156,7 @@ if [ "$LOCAL_ADDR" != "common" ];then
 fi
 
 if [ -f /etc/motd ];then
-    echo "welcome to mdserver-web panel" > /etc/motd
+    echo "welcome to PowerLinux panel" > /etc/motd
 fi
 
 startTime=`date +%s`
@@ -234,12 +237,13 @@ if [ $OSNAME != "macos" ];then
 	mkdir -p /www/backup/site
 
 	if [ ! -d /www/server/mdserver-web ];then
-		echo "downloading ${HTTP_PREFIX}github.com/midoks/mdserver-web/archive/refs/heads/dev.tar.gz"
-		curl --insecure -sSLo /tmp/dev.tar.gz ${HTTP_PREFIX}github.com/midoks/mdserver-web/archive/refs/heads/dev.tar.gz
+		echo "downloading ${HTTP_PREFIX}github.com/${REPO_OWNER}/${REPO_NAME}/archive/refs/heads/${REPO_BRANCH}.tar.gz"
+		curl --insecure -sSLo /tmp/dev.tar.gz ${HTTP_PREFIX}github.com/${REPO_OWNER}/${REPO_NAME}/archive/refs/heads/${REPO_BRANCH}.tar.gz
+		TARBALL_DIR=$(tar -tf /tmp/dev.tar.gz | head -1 | cut -d/ -f1)
 		cd /tmp && tar -zxvf /tmp/dev.tar.gz
-		mv -f /tmp/mdserver-web-dev /www/server/mdserver-web
+		mv -f /tmp/${TARBALL_DIR} /www/server/mdserver-web
 		rm -rf /tmp/dev.tar.gz
-		rm -rf /tmp/mdserver-web-dev
+		rm -rf /tmp/${TARBALL_DIR}
 	fi
 
 	# install acme.sh
@@ -258,7 +262,7 @@ fi
 echo "use system version: ${OSNAME}"
 
 if [ "${OSNAME}" == "macos" ];then
-	curl --insecure -fsSL ${HTTP_PREFIX}raw.githubusercontent.com/midoks/mdserver-web/refs/heads/dev/scripts/install/macos.sh | bash
+	curl --insecure -fsSL ${HTTP_PREFIX}raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/scripts/install/macos.sh | bash
 else
 	cd /www/server/mdserver-web && bash scripts/install/${OSNAME}.sh
 fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -5,7 +5,7 @@ export PATH
 is64bit=`getconf LONG_BIT`
 REPO_OWNER="AndyXeCM"
 REPO_NAME="PowerLinux"
-REPO_BRANCH="master"
+REPO_BRANCH="main"
 
 startTime=`date +%s`
 

--- a/scripts/update_dev.sh
+++ b/scripts/update_dev.sh
@@ -16,6 +16,9 @@ WORKING='[\033[34m*\033[0m]'
 
 # LANG=en_US.UTF-8
 is64bit=`getconf LONG_BIT`
+REPO_OWNER="AndyXeCM"
+REPO_NAME="PowerLinux"
+REPO_BRANCH="main"
 
 startTime=`date +%s`
 
@@ -214,19 +217,16 @@ if [ -f /tmp/dev.tar.gz ];then
 	rm -rf /tmp/dev.tar.gz
 fi
 
-if [ -d /tmp/mdserver-web-dev ];then
-	rm -rf /tmp/mdserver-web-dev
-fi
+echo "update PowerLinux dev code start"
 
-echo "update mdserver-web dev code start"
-
-curl --insecure -sSLo /tmp/dev.tar.gz ${HTTP_PREFIX}github.com/midoks/mdserver-web/archive/refs/heads/dev.tar.gz
+curl --insecure -sSLo /tmp/dev.tar.gz ${HTTP_PREFIX}github.com/${REPO_OWNER}/${REPO_NAME}/archive/refs/heads/${REPO_BRANCH}.tar.gz
+TARBALL_DIR=$(tar -tf /tmp/dev.tar.gz | head -1 | cut -d/ -f1)
 cd /tmp && tar -zxvf /tmp/dev.tar.gz
-$CP_CMD -rf /tmp/mdserver-web-dev/* /www/server/mdserver-web
+$CP_CMD -rf /tmp/${TARBALL_DIR}/* /www/server/mdserver-web
 rm -rf /tmp/dev.tar.gz
-rm -rf /tmp/mdserver-web-dev
+rm -rf /tmp/${TARBALL_DIR}
 
-echo "update mdserver-web dev code end"
+echo "update PowerLinux dev code end"
 
 
 #pip uninstall public

--- a/web/utils/system/update.py
+++ b/web/utils/system/update.py
@@ -15,8 +15,85 @@ import time
 import math
 import psutil
 import json
+import html
 
 import core.mw as mw
+
+PANEL_REPO_OWNER = 'AndyXeCM'
+PANEL_REPO_NAME = 'PowerLinux'
+PANEL_RELEASE_API = 'https://api.github.com/repos/%s/%s/releases/latest' % (PANEL_REPO_OWNER, PANEL_REPO_NAME)
+PANEL_RELEASE_PAGE = 'https://github.com/%s/%s/releases/latest' % (PANEL_REPO_OWNER, PANEL_REPO_NAME)
+
+
+def _normalize_version_name(version):
+    version = str(version or '').strip()
+    if version.startswith('v') and len(version) > 1 and version[1].isdigit():
+        version = version[1:]
+    return version
+
+
+def _strip_html_tags(content):
+    content = re.sub(r'(?i)<br\s*/?>', '\n', content)
+    content = re.sub(r'(?i)</p\s*>', '\n\n', content)
+    content = re.sub(r'(?i)</div\s*>', '\n', content)
+    content = re.sub(r'(?i)</li\s*>', '\n', content)
+    content = re.sub(r'(?i)<li[^>]*>', ' - ', content)
+    content = re.sub(r'<[^>]+>', '', content)
+    return html.unescape(content).strip()
+
+
+def _parse_release_page(result):
+    tag_name = ''
+    release_name = ''
+
+    title_match = re.search(r'<title>(.*?)</title>', result, re.S | re.I)
+    if title_match is not None:
+        title = title_match.group(1)
+        title = re.sub(r'\s*·\s*[^<]+$', '', title).strip()
+        title = re.sub(r'(?i)^release\s+', '', title).strip()
+        if title != '':
+            release_name = title
+            version_match = re.search(r'(\d+(?:\.\d+)+)\s*$', release_name)
+            if version_match is not None:
+                tag_name = version_match.group(1)
+
+    if tag_name == '':
+        tag_candidates = re.findall(r'/[^/]+/[^/]+/releases/tag/([^"\'?#/]+)', result)
+        for candidate in tag_candidates:
+            candidate = _normalize_version_name(candidate)
+            if re.match(r'^\d+(?:\.\d+)+$', candidate) is not None:
+                tag_name = candidate
+                break
+
+    if release_name == '':
+        release_name = tag_name
+
+    if tag_name == '':
+        return None
+
+    body_match = re.search(r'<div[^>]+class="[^"]*markdown-body[^"]*"[^>]*>(.*?)</div>', result, re.S | re.I)
+    body = ''
+    if body_match is not None:
+        body = _strip_html_tags(body_match.group(1))
+
+    return {
+        'tag_name': tag_name,
+        'name': release_name,
+        'body': body,
+        'html_url': 'https://github.com/%s/%s/releases/tag/%s' % (PANEL_REPO_OWNER, PANEL_REPO_NAME, tag_name),
+    }
+
+
+def _release_version(version_new_info):
+    version = _normalize_version_name(version_new_info.get('tag_name', ''))
+    if version == '':
+        version = _normalize_version_name(version_new_info.get('version', ''))
+    if version == '':
+        version = _normalize_version_name(version_new_info.get('name', ''))
+        match = re.search(r'(\d+(?:\.\d+)+)', version)
+        if match is not None:
+            version = match.group(1)
+    return version
 
 def versionDiff(now, new):
     '''
@@ -24,6 +101,11 @@ def versionDiff(now, new):
         new 有新版本
         none 没有新版本
     '''
+    now = _normalize_version_name(now)
+    new = _normalize_version_name(new)
+    if now == '' or new == '':
+        return 'none'
+
     new_list = new.split('.')
     if len(new_list) > 3:
         return 'test'
@@ -39,16 +121,34 @@ def versionDiff(now, new):
 def getServerInfo():
     import urllib.request
     import ssl
-    upAddr = 'https://api.github.com/repos/midoks/mdserver-web/releases/latest'
+    headers = {
+        'User-Agent': 'PowerLinux-Updater/1.0',
+        'Accept': 'application/vnd.github+json',
+    }
+    upAddrList = [PANEL_RELEASE_API, PANEL_RELEASE_PAGE]
+    last_error = None
     try:
         context = ssl._create_unverified_context()
-        req = urllib.request.urlopen(upAddr, context=context, timeout=3)
-        result = req.read().decode('utf-8')
-        version = json.loads(result)
-        return version
+        for upAddr in upAddrList:
+            try:
+                req = urllib.request.Request(upAddr, headers=headers)
+                resp = urllib.request.urlopen(req, context=context, timeout=5)
+                result = resp.read().decode('utf-8')
+                if upAddr == PANEL_RELEASE_API:
+                    version = json.loads(result)
+                    if isinstance(version, dict) and version.get('tag_name'):
+                        return version
+                else:
+                    version = _parse_release_page(result)
+                    if version is not None:
+                        return version
+            except Exception as e:
+                last_error = e
     except Exception as e:
         print(str(e))
         return None
+    if last_error is not None:
+        print(str(last_error))
     return None
 
 def updateServer(stype, version=''):
@@ -62,8 +162,8 @@ def updateServer(stype, version=''):
         if version_new_info is None:
             return mw.returnData(False, '服务器数据或网络有问题!')
 
-        version_now = config.APP_VERSION
-        new_ver = version_new_info['name']
+        version_now = _normalize_version_name(config.APP_VERSION)
+        new_ver = _release_version(version_new_info)
         if stype == 'check':
             diff = versionDiff(version_now, new_ver)
             if diff == 'new':
@@ -77,7 +177,10 @@ def updateServer(stype, version=''):
             diff = versionDiff(version_now, new_ver)
             data = {}
             data['version'] = new_ver
-            data['content'] = version_new_info['body'].replace("\n", "<br/>")
+            content = str(version_new_info.get('body', ''))
+            if content.strip() == '':
+                content = '当前版本来自 GitHub Release，未提供更新说明。'
+            data['content'] = content.replace("\n", "<br/>")
             return mw.returnData(True, '更新信息!', data)
 
         if stype == 'update':
@@ -91,20 +194,21 @@ def updateServer(stype, version=''):
             if not os.path.exists(toPath):
                 mw.execShell('mkdir -p ' + toPath)
 
-            newUrl = "https://github.com/midoks/mdserver-web/archive/refs/tags/" + version + ".zip"
+            version = _normalize_version_name(version)
+            newUrl = "https://github.com/%s/%s/archive/refs/tags/%s.zip" % (PANEL_REPO_OWNER, PANEL_REPO_NAME, version)
 
             dist_mw = toPath + '/mw.zip'
             if not os.path.exists(dist_mw):
                 mw.execShell('wget --no-check-certificate -O ' + dist_mw + ' ' + newUrl)
 
-            dist_to = toPath + "/mdserver-web-" + version
+            dist_to = toPath + "/PowerLinux-" + version
             if not os.path.exists(dist_to):
                 os.system('unzip -o ' + toPath + '/mw.zip' + ' -d ' + toPath)
 
-            cmd_cp = 'cp -rf ' + toPath + '/mdserver-web-' + version + '/* ' + mw.getServerDir() + '/mdserver-web'
+            cmd_cp = 'cp -rf ' + toPath + '/PowerLinux-' + version + '/* ' + mw.getServerDir() + '/mdserver-web'
             mw.execShell(cmd_cp)
 
-            mw.execShell('rm -rf ' + toPath + '/mdserver-web-' + version)
+            mw.execShell('rm -rf ' + toPath + '/PowerLinux-' + version)
             mw.execShell('rm -rf ' + toPath + '/mw.zip')
 
             update_env = '''
@@ -144,7 +248,4 @@ fi
     except Exception as ex:
         # print('updateServer', ex)
         return mw.returnData(False, "连接服务器失败!" + str(ex))
-
-
-
 


### PR DESCRIPTION
Switch the panel update flow to PowerLinux's own GitHub releases instead of the original mwpanel release source.\n\nWhat changed:\n- Update the panel update checker to read PowerLinux release metadata and download release archives\n- Point install/update scripts and init.d entrypoints at AndyXeCM/PowerLinux on main\n- Keep the dev install/update helpers aligned with the same repo\n\nValidation:\n- python3 -m py_compile web/utils/system/update.py web/admin/system/upgrade.py\n- bash -n scripts/install.sh scripts/update.sh scripts/install_dev.sh scripts/update_dev.sh scripts/install/macos.sh scripts/init.d/mw.tpl scripts/init.d/mw\n- git diff --check\n- Standalone release parser check returned tag 3.0