### PR TITLE
Fix software store icon display sizing

### DIFF
--- a/web/static/app/soft.js
+++ b/web/static/app/soft.js
@@ -184,14 +184,15 @@ function getSList(isdisplay) {
                 plugin_title = plugin.title + ' ' + plugin.setup_version;
             }
 
-            icon_link = "/plugins/file?name="+plugin.name+"&f=ico.png";
-            if (plugin.icon != ''){
-                icon_link = "/plugins/file?name="+plugin.name+"&f="+plugin.icon;
+            var iconLink = "/plugins/file?name=" + plugin.name + "&f=ico.png";
+            if (plugin.icon) {
+                iconLink = "/plugins/file?name=" + plugin.name + "&f=" + plugin.icon;
             }
 
             sBody += '<tr>' +
-                '<td><span ' + titleClick + '>'+
-                '<img data-src="'+icon_link+'" src="/static/img/loading.gif">' + plugin_title + '</span></td>' +
+                '<td><span class="mw-soft-plugin-name" ' + titleClick + '>' +
+                '<span class="mw-soft-plugin-icon"><img data-src="' + iconLink + '" src="/static/img/loading.gif" alt="' + escapeHtml(plugin_title) + '"></span>' +
+                '<span class="mw-soft-plugin-title">' + plugin_title + '</span></span></td>' +
                 '<td>' + plugin.ps + '</td>' +
                 '<td>' + softPath + '</td>' +
                 '<td>' + state + '</td>' +

--- a/web/static/css/mdui2-theme.css
+++ b/web/static/css/mdui2-theme.css
@@ -3531,6 +3531,41 @@ mdui-button::part(button) {
     vertical-align: middle;
 }
 
+.mw-soft-plugin-name {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    max-width: 100%;
+}
+
+.mw-soft-plugin-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    min-width: 48px;
+    height: 48px;
+    padding: 6px;
+    border-radius: 14px;
+    overflow: hidden;
+    background: color-mix(in srgb, var(--mw-surface-container) 88%, transparent);
+    border: 1px solid color-mix(in srgb, var(--mw-border) 82%, transparent);
+    box-sizing: border-box;
+}
+
+.mw-soft-plugin-icon img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.mw-soft-plugin-title {
+    display: inline-block;
+    min-width: 0;
+    word-break: break-word;
+}
+
 /* file manager */
 .mw-file-toolbar {
     overflow: visible;


### PR DESCRIPTION
## Summary
- constrain software store plugin icons to a fixed visual container
- prevent oversized plugin images from stretching table rows and pagination
- make icon URL selection safer when plugin metadata omits a custom icon

## Testing
- not run (UI-only change; verified by code inspection and generated diff)